### PR TITLE
Add VHDL analysis tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -211,6 +211,8 @@ RUN echo 'deb http://ftp.fr.debian.org/debian/ bullseye main contrib non-free' >
             make=4.3-* \
     ##patch for problem with previous too old version
     && apt-get install -y libzarith-ocaml libtinfo5 gcc  g\+\+\
+    ##x needed for elipse
+    && apt-get install -y xvfb libswt-gtk-4-jni libswt-gtk-4-java\
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/local/man \
     # Install pylint and CNES pylint extension
@@ -230,20 +232,22 @@ RUN echo 'deb http://ftp.fr.debian.org/debian/ bullseye main contrib non-free' >
             astroid==2.4.0 \
             pylint==2.5.0 \
     # Infer
-    && ln -s "/opt/infer-linux64-v0.17.0/bin/infer" /usr/local/bin/infer
+    && ln -s "/opt/infer-linux64-v0.17.0/bin/infer" /usr/local/bin/infer 
+
 
 # Make sonar-scanner, CNES pylint and C/C++ tools executable
 ENV PYTHONPATH="$PYTHONPATH:/opt/python/cnes-pylint-extension-5.0.0/checkers" \
     PATH="$SONAR_SCANNER_HOME/bin:/usr/local/bin:$PATH" \
     PYLINTHOME="$SONAR_SCANNER_HOME/.pylint.d" \
-    JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64" 
+    JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64" \
+    DISPLAY=":0"
 
 # Switch to an unpriviledged user
 USER sonar-scanner
-
-# Set the entrypoint (a SonarSource script) and the default command (sonar-scanner)
+#add fake screen kickstart . this fake screen is needed by eclipse
+COPY --chown=sonar-scanner:sonar-scanner scripts/kickstartfakedisplay.sh /usr/bin
+# copy the entrypoint (a SonarSource script) and the default command (sonar-scanner)
 COPY --chown=sonar-scanner:sonar-scanner scripts/entrypoint.sh /usr/bin
-ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
+# Set the entrypoint
+ENTRYPOINT [ "/usr/bin/kickstartfakedisplay.sh" ]
 CMD [ "sonar-scanner" ]
-#CMD [ "cat /opt/sonar-scanner/rc/App/eclipse/configuration/*.log"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,6 +131,7 @@ RUN addgroup sonar-scanner \
             "$SRC_DIR" \
     && chmod -R 777 \
             "$SONAR_SCANNER_HOME/.sonar" \
+            "$SONAR_SCANNER_HOME/rc" \
             "$SONAR_SCANNER_HOME/.pylint.d" \
             "$SRC_DIR"
 
@@ -144,6 +145,11 @@ COPY conf/sonar-scanner.properties "$SONAR_SCANNER_HOME/conf"
 #add VHDL RC engine
 COPY --from=builder /sonar-scanner/rc/ \
     "$SONAR_SCANNER_HOME/rc"
+#give ownership to user (for write and execution)
+RUN chown -R sonar-scanner:sonar-scanner "$SONAR_SCANNER_HOME/rc"
+RUN chmod -R 777 "$SONAR_SCANNER_HOME/rc" 
+
+
 #TODO add yosys from builder
 COPY --from=builder /usr/local/bin/yosys /usr/local/bin/yosys
 COPY --from=builder /usr/local/bin/yosys-abc /usr/local/bin/yosys-abc

--- a/Dockerfile
+++ b/Dockerfile
@@ -213,6 +213,8 @@ RUN echo 'deb http://ftp.fr.debian.org/debian/ bullseye main contrib non-free' >
     && apt-get install -y libzarith-ocaml libtinfo5 gcc  g\+\+\
     ##x needed for elipse
     && apt-get install -y xvfb libswt-gtk-4-jni libswt-gtk-4-java\
+    ## needed for ghdl
+    && apt-get install -y gnat\ 
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/local/man \
     # Install pylint and CNES pylint extension

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,18 +145,16 @@ COPY conf/sonar-scanner.properties "$SONAR_SCANNER_HOME/conf"
 #add VHDL RC engine
 COPY --from=builder /sonar-scanner/rc/ \
     "$SONAR_SCANNER_HOME/rc"
-#give ownership to user (for write and execution)
+#give ownership to user (for write and execution) for VHDL RC engine
 RUN chown -R sonar-scanner:sonar-scanner "$SONAR_SCANNER_HOME/rc"
 RUN chmod -R 777 "$SONAR_SCANNER_HOME/rc" 
-
-
-#TODO add yosys from builder
+# add yosys from builder
 COPY --from=builder /usr/local/bin/yosys /usr/local/bin/yosys
 COPY --from=builder /usr/local/bin/yosys-abc /usr/local/bin/yosys-abc
 COPY --from=builder /usr/local/bin/yosys-config /usr/local/bin/yosys-config
 COPY --from=builder /usr/local/bin/yosys-filterlib /usr/local/bin/yosys-filterlib
 COPY --from=builder /usr/local/bin/yosys-smtbmc /usr/local/bin/yosys-smtbmc
-#TODO add ghdl from builder
+# add ghdl from builder
 COPY --from=builder /usr/local/lib/libghdl.a /usr/local/lib/libghdl.a 
 COPY --from=builder /usr/local/lib/libghdl.link /usr/local/lib/libghdl.link 
 COPY --from=builder /usr/local/lib/libghdl-1_0_dev.so /usr/local/lib/libghdl-1_0_dev.so 
@@ -211,6 +209,7 @@ RUN echo 'deb http://ftp.fr.debian.org/debian/ bullseye main contrib non-free' >
             ##g\+\+=4:10.1.0-* \
             clang=1:9.0-* \
             make=4.3-* \
+    ##patch for problem with previous too old version
     && apt-get install -y libzarith-ocaml libtinfo5 gcc  g\+\+\
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/local/man \
@@ -237,7 +236,7 @@ RUN echo 'deb http://ftp.fr.debian.org/debian/ bullseye main contrib non-free' >
 ENV PYTHONPATH="$PYTHONPATH:/opt/python/cnes-pylint-extension-5.0.0/checkers" \
     PATH="$SONAR_SCANNER_HOME/bin:/usr/local/bin:$PATH" \
     PYLINTHOME="$SONAR_SCANNER_HOME/.pylint.d" \
-    JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
+    JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64" 
 
 # Switch to an unpriviledged user
 USER sonar-scanner
@@ -246,3 +245,5 @@ USER sonar-scanner
 COPY --chown=sonar-scanner:sonar-scanner scripts/entrypoint.sh /usr/bin
 ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
 CMD [ "sonar-scanner" ]
+#CMD [ "cat /opt/sonar-scanner/rc/App/eclipse/configuration/*.log"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN echo 'deb http://ftp.fr.debian.org/debian/ bullseye main contrib non-free' >
         libyojson-ocaml-dev=1.7.0-* \
         ##not found##libzarith-ocaml-dev=1.9.1-* \
         menhir=20200624-* \
+    #patch florent to be removed
+    && apt-get install -y libzarith-ocaml-dev g\+\+ \
         #for yosys
     && apt-get install -y build-essential clang bison flex \
         libreadline-dev gawk tcl-dev libffi-dev git \
@@ -140,10 +142,21 @@ COPY --from=builder /sonar-scanner/lib \
 # and our default sonar-scanner.properties
 COPY conf/sonar-scanner.properties "$SONAR_SCANNER_HOME/conf"
 #add VHDL RC engine
-COPY --from=builder /sonar-scanner/bin/rc/ \
+COPY --from=builder /sonar-scanner/rc/ \
     "$SONAR_SCANNER_HOME/rc"
 #TODO add yosys from builder
+COPY --from=builder /usr/local/bin/yosys /usr/local/bin/yosys
+COPY --from=builder /usr/local/bin/yosys-abc /usr/local/bin/yosys-abc
+COPY --from=builder /usr/local/bin/yosys-config /usr/local/bin/yosys-config
+COPY --from=builder /usr/local/bin/yosys-filterlib /usr/local/bin/yosys-filterlib
+COPY --from=builder /usr/local/bin/yosys-smtbmc /usr/local/bin/yosys-smtbmc
 #TODO add ghdl from builder
+COPY --from=builder /usr/local/lib/libghdl.a /usr/local/lib/libghdl.a 
+COPY --from=builder /usr/local/lib/libghdl.link /usr/local/lib/libghdl.link 
+COPY --from=builder /usr/local/lib/libghdl-1_0_dev.so /usr/local/lib/libghdl-1_0_dev.so 
+COPY --from=builder /usr/local/lib/libghdlvpi.so /usr/local/lib/libghdlvpi.so 
+COPY --from=builder /usr/local/lib/ghdl /usr/local/lib/ghdl
+COPY --from=builder /usr/local/bin/ghdl /usr/local/bin/ghdl 
 
 # Add CppCheck from builder stage
 COPY --from=builder /usr/share/cppcheck /usr/share/cppcheck
@@ -181,17 +194,18 @@ RUN echo 'deb http://ftp.fr.debian.org/debian/ bullseye main contrib non-free' >
             # Needed by Frama-C
             ocaml-findlib=1.8.1-* \
             libocamlgraph-ocaml-dev=1.8.8-* \
-            libzarith-ocaml=1.9.1-* \
+            #libzarith-ocaml=1.9.1-* \
             libyojson-ocaml=1.7.0-* \
             # Needed by Infer
             libsqlite3-0=3.33.0-* \
-            libtinfo5=6.2-* \
+            #libtinfo5=6.2-* \
             python2.7=2.7.18-* \
             # Compilation tools needed by Infer
-            gcc=4:10.1.0-* \
-            g\+\+=4:10.1.0-* \
+            #gcc=4:10.1.0-* \
+            ##g\+\+=4:10.1.0-* \
             clang=1:9.0-* \
             make=4.3-* \
+    && apt-get install -y libzarith-ocaml libtinfo5 gcc  g\+\+\
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/local/man \
     # Install pylint and CNES pylint extension

--- a/README.md
+++ b/README.md
@@ -275,11 +275,26 @@ To then run a container with this image see the [user guide](#user-guide).
 To run the tests and create your own ones see the [test documentation](https://github.com/cnescatlab/sonar-scanner/tree/develop/tests).
 
 ### Debugging the image
-If analysis doesn't perform correctly you can inspect the image by loggin into it running:
+If analysis doesn't perform correctly you can inspect the image by doing the following sequence:
+1. launch the container with a shell (the entrypoint script is not ran).   
+In this case, a bridge was created as sonarbridge to link with the soanrqube container which can be address with IP 172.18.0.2. Notice that the container was given a name : lequalscanner.
 ```sh
-docker run -it lequal/sonar-scanner sh 
-```
+docker run --name lequalscanner --net sonarbridge --rm  -e SONAR_HOST_URL="http://172.18.0.2:9000" -it lequal/sonar-scanner sh 
 
+```
+2. Run the following script (on a new windows powershell)
+```sh
+#get container ID and store it in a variable
+$DOCKERID=docker ps -aqf "name=lequalscanner"  
+#copy your sources in the scanner container (you're supposed to be located in your sources directory when executing this script)
+docker cp .  ${DOCKERID}:/usr/src
+#change ownership of the sources
+docker exec -u root  ${DOCKERID} bash -c 'chown -R sonar-scanner:sonar-scanner /usr/src'
+```
+3. Do what ever you needed to be done. You can launch sonar scanner analysis by running the following command in the container shell and then debug the result
+```sh
+entrypoint.sh -X.
+```
 ## How to contribute
 
 If you experienced a problem with the image please open an issue. Inside this issue please explain us how to reproduce this issue and paste the log. 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ If analysis doesn't perform correctly you can inspect the image by doing the fol
 1. launch the container with a shell (the entrypoint script is not ran).   
 In this case, a bridge was created as sonarbridge to link with the soanrqube container which can be address with IP 172.18.0.2. Notice that the container was given a name : lequalscanner.
 ```sh
-docker run --name lequalscanner --net sonarbridge --rm  -e SONAR_HOST_URL="http://172.18.0.2:9000" -it lequal/sonar-scanner sh 
+docker run --name lequalscanner --net sonarbridge --rm  -e SONAR_HOST_URL="http://172.18.0.2:9000" -it --entrypoint /bin/sh lequal/sonar-scanner  
 
 ```
 2. Run the following script (on a new windows powershell)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ _This image is made to be used in conjunction with a pre-configured SonarQube se
       # add the following option to the command line when running the lequal/sonar-scanner
       --net sonarbridge
       ```
+    * To find you server IP you can eexecute the following commands:   
+      Get the sonarqube server Container ID by running:
+      ```sh
+      docker ps
+      ```
+      Use this Container ID to get the dedicated IP address:
+      ```sh
+      docker inspect -f '{{range .NetworkSettings.Networks}} {{.IPAddress}}{{end}}' <MySonarqubeDockerID>
+       ```
 
 This image suffers from the same limitations as the official SonarQube [sonarsource/sonar-scanner-cli](https://hub.docker.com/r/sonarsource/sonar-scanner-cli) image.
 
@@ -245,6 +254,8 @@ sonar-scanning:
 | [RATS](https://code.google.com/archive/p/rough-auditing-tool-for-security/)    | 2.4           | rats-report.xml     |
 | [Frama-C](https://frama-c.com/index.html)                                      | 20.0          |                     |
 | [Infer](https://fbinfer.com/)                                                  | 0.17.0        |                     |
+| [VHDLRC](https://github.com/VHDLTool/sonar-VHDLRC)                             | 1.8.043       |                     |
+
 
 ## Developer's guide
 
@@ -262,6 +273,12 @@ $ docker build -t lequal/sonar-scanner .
 To then run a container with this image see the [user guide](#user-guide).
 
 To run the tests and create your own ones see the [test documentation](https://github.com/cnescatlab/sonar-scanner/tree/develop/tests).
+
+### Debugging the image
+If analysis doesn't perform correctly you can inspect the image by loggin into it running:
+```sh
+docker run -it lequal/sonar-scanner sh 
+```
 
 ## How to contribute
 

--- a/conf/sonar-scanner.properties
+++ b/conf/sonar-scanner.properties
@@ -12,3 +12,7 @@ sonar.cxx.cppcheck.reportPath=cppcheck-report.xml
 sonar.cxx.vera.reportPath=vera-report.xml
 sonar.cxx.rats.reportPath=rats-report.xml
 sonar.python.pylint.reportPath=pylint-report.txt
+
+#default path for VHDL tool
+#FIXME: this path should be $SONAR_SCANNER_HOME shell variable
+sonar.vhdlrc.scanner.home=/opt/sonar-scanner 

--- a/scripts/kickstartfakedisplay.sh
+++ b/scripts/kickstartfakedisplay.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+#run fake display
+Xvfb :0 &
+#run sonarscanner entry file
+/usr/bin/entrypoint.sh

--- a/scripts/kickstartfakedisplay.sh
+++ b/scripts/kickstartfakedisplay.sh
@@ -3,4 +3,4 @@
 #run fake display
 Xvfb :0 &
 #run sonarscanner entry file
-/usr/bin/entrypoint.sh
+/usr/bin/entrypoint.sh "$@" 


### PR DESCRIPTION
## Proposed changes

This update includes additionnal features needed to scan VHDL projects:
* An eclipse with vhdl rulechecker is installed. This eclipse needed a x server which is based on Xvfb.
   To allow launch of the fake display ahead of scanner analysis a new entrypoint was created for the image. 
   This new entrypoint (kickstartfakedisplay.sh) launch Xvfb and pass every parameters to the default entrypoint.sh  
* ghdl (VHDL simulator) is added (compiled from github [sources](https://github.com/ghdl/ghdl)) to be able to run vhdl test bench coverage
* yosys (open source synthetizer) is added (compiled from github [sources](https://github.com/YosysHQ/yosys)) to be able to run new vhdl rules.
* ghdl plugin for yosys is added (compiled from github [sources](https://github.com/ghdl/ghdl-yosys-plugin)) to include VHDL support to yosys.

As soon as tests are converted to pytests, tests will be added to check vhdl feature.

## Types of changes
Scanner includes softwares needed for VHDL analysis.
Readme was improved to help debugging docker VM.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] Documentation Update (if none of the other choices apply)

## Issues closed by changes
- [x] Close #0

## Checklist

> _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ x] I agree with the [CODE OF CONDUCT](CODE_OF_CONDUCT.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] I have added necessary documentation (if appropriate)
- [x ] Any dependent changes have been merged and published in downstream modules
